### PR TITLE
add troubleshooting details for script-failure

### DIFF
--- a/src/builtins/v1/mkCons.js
+++ b/src/builtins/v1/mkCons.js
@@ -34,7 +34,7 @@ export const mkCons = {
 
         if (!list.itemType.isEqual(item.type)) {
             throw new Error(
-                `item type doesn't correspond with list type in mkCons`
+                `item type doesn't correspond with list type in mkCons; expected ${list.itemType.toString()}, got ${item.type.toString()}`
             )
         }
 

--- a/src/cek/UplcRuntimeError.js
+++ b/src/cek/UplcRuntimeError.js
@@ -1,11 +1,19 @@
 import { stringifyCekValue } from "./CekValue.js"
 
 /**
- * @import { CallSiteInfo, CekValue } from "../index.js"
+ * @import { CallSiteInfo, CekValue, UplcData } from "../index.js"
  */
 
 export class UplcRuntimeError extends Error {
     /**
+     * Optional field indicating a ScriptContext (UPLC) in which the error occurred
+     * @readonly
+     * @type {UplcData | undefined}
+     */
+    scriptContext
+
+    /**
+     * private field so that it doesn't show up when the error isn't caught (i.e. not enumerable)
      * @readonly
      * @type {CallSiteInfo[]}
      */
@@ -14,8 +22,9 @@ export class UplcRuntimeError extends Error {
     /**
      * @param {string} message
      * @param {CallSiteInfo[]} callSites
+     * @param {UplcData} [scriptContext]
      */
-    constructor(message, callSites = []) {
+    constructor(message, callSites = [], scriptContext) {
         super(message)
 
         this.frames = callSites
@@ -25,6 +34,12 @@ export class UplcRuntimeError extends Error {
             writable: true,
             configurable: false
         })
+        Object.defineProperty(this, "scriptContext", {
+            enumerable: false,
+            writable: true,
+            configurable: false
+        })
+        this.scriptContext = scriptContext
 
         prepareHeliosStackTrace(this, callSites)
     }

--- a/src/data/ConstrData.js
+++ b/src/data/ConstrData.js
@@ -103,12 +103,20 @@ class ConstrDataImpl {
     fields
 
     /**
+     * @readonly
+     * @type {string | undefined}
+     */
+    dataPath
+
+    /**
      * @param {IntLike} tag
      * @param {UplcData[]} fields
+     * @param {string} [dataPath]
      */
-    constructor(tag, fields) {
+    constructor(tag, fields, dataPath) {
         this.tag = toInt(tag)
         this.fields = fields
+        this.dataPath = dataPath
     }
 
     /**


### PR DESCRIPTION
 - show more info when item type doesn't match list-type in mkCons
 - includes scriptContext (non-enumerable for clean stack)
 - adds optional dataPath prop to ConstrData, to match UplcData's allows [ScriptContext] to be obviously stamped into that arg as part of the program setup