### PR TITLE
Improve test-coverage of ConstrData

### DIFF
--- a/src/data/ConstrData.test.js
+++ b/src/data/ConstrData.test.js
@@ -1,4 +1,4 @@
-import { strict as assert } from 'node:assert';
+import { strictEqual } from 'node:assert';
 import { test } from 'node:test';
 import { makeConstrData } from './ConstrData.js';
 import { UPLC_DATA_NODE_MEM_SIZE } from './UplcData.js';
@@ -13,5 +13,5 @@ test('ConstrData.memSize', () => {
     // Assume UPLC_DATA_NODE_MEM_SIZE is a constant import, adjust based on your logic.
     const expectedMemSize = UPLC_DATA_NODE_MEM_SIZE + testFields.reduce((sum, field) => sum + field.memSize, 0);
 
-    assert.equal(constrData.memSize, expectedMemSize);
+    strictEqual(constrData.memSize, expectedMemSize);
 });

--- a/src/data/ConstrData.test.js
+++ b/src/data/ConstrData.test.js
@@ -1,0 +1,17 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { makeConstrData } from './ConstrData.js';
+import { UPLC_DATA_NODE_MEM_SIZE } from './UplcData.js';
+
+// Boilerplate unit tests for ConstrData
+
+test('ConstrData.memSize', () => {
+    const testTag = 1;
+    const testFields = [{ memSize: 5 }, { memSize: 10 }];
+    const constrData = makeConstrData(testTag, testFields);
+
+    // Assume UPLC_DATA_NODE_MEM_SIZE is a constant import, adjust based on your logic.
+    const expectedMemSize = UPLC_DATA_NODE_MEM_SIZE + testFields.reduce((sum, field) => sum + field.memSize, 0);
+
+    assert.equal(constrData.memSize, expectedMemSize);
+});


### PR DESCRIPTION
Analyzed the content of src/data/ConstrData.js and created a new test file src/data/ConstrData.test.js. Implemented boilerplate code using 'node:test' and 'node:assert' libraries similar to existing unit test files, specifically IntData.test.js. Added a unit test for the ConstrData.memSize method to ensure it calculates the memory size correctly, accounting for both the base size and the size of its fields.

Resolves #6